### PR TITLE
Initializing init and respBody

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ async function fetchGetHtml(url) {
 
 addEventListener('fetch', async event => {
   const { url, method } = event.request
-
+  let init, respBody;
   // Set respBody and init according to the route
   // and method of the incoming request
   if (url.endsWith('/html')) {


### PR DESCRIPTION
Fixing following errors:
Uncaught (in promise) ReferenceError: respBody is not defined
    at VM13 worker.js:113
Uncaught (in promise) ReferenceError: init is not defined
    at VM13 worker.js:115